### PR TITLE
Include default config files when installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,5 @@ setup(name = 'csat2',
                         'pyhdf'],
       packages = ['csat2'],
       package_dir = {'csat2': 'csat2'},
-      package_data = {'csat2': ['data/*']}
+      package_data = {'csat2': ['data/*', 'config/*']}
 )


### PR DESCRIPTION
Config files weren't installed into the environment instance of the package properly without this change - it meant that an error was hit unless csat2 config was relative to the working directory.