### PR TITLE
BUGFIX: Levels populated as None in unpacking infrastructure

### DIFF
--- a/csat2/ECMWF/variables.py
+++ b/csat2/ECMWF/variables.py
@@ -39,3 +39,4 @@ def _get_levelstr(level):
         if isinstance(level, int):
             level = "{.0f}".format(level)
         levelstr = "{}hPa".format(level)
+    return levelstr


### PR DESCRIPTION
Fixes a breaking bug where imported and downloaded ERA5 data was mislabeled in the csat2 datastore.

Arose as the "levelstr" was left unset due to a missing return statement.