### PR TITLE
Modis geolocation update

### DIFF
--- a/csat2/MODIS/granule.py
+++ b/csat2/MODIS/granule.py
@@ -213,6 +213,9 @@ class Granule(object):
             zip(self.lonlat[0][mlocslon, mlocslat], self.lonlat[1][mlocslon, mlocslat])
         )
 
+    def geolocate(self, mlocs):
+        return self.mloc_to_lonlat(mlocs)
+    
     def get_angles(self, mst=False, product=None, col=None, dateline=False):
         """Get the solar and scattering angles for a MODIS/VIIRS image
         Returns solar zenith, azimuth, satellite zenith, azimuth

--- a/csat2/MODIS/granule.py
+++ b/csat2/MODIS/granule.py
@@ -12,7 +12,6 @@ from .readfiles import (
 from .util import band_centres, bowtie_correct
 from .download import download, download_geometa, check
 import numpy as np
-from sklearn.neighbors import BallTree
 from scipy.spatial import KDTree
 import scipy.constants
 from netCDF4 import Dataset
@@ -153,7 +152,7 @@ class Granule(object):
 
     def locate(self, locs,
                rectified=False, product=None, col=None,
-               locator_type='BallTree',
+               locator_type='SphereRemap2km',
                **kwargs):
         """Returns the locations in the granule of lon,lat pairs,
         is an instance of MODISlocator"""
@@ -175,7 +174,7 @@ class Granule(object):
             return self.locator.locate(locs, **kwargs)
 
     def points_in_radius(self, loc, dist=20,
-                         locator_type='BallTree', **kwargs):
+                         locator_type='SphereRemap2km', **kwargs):
         if not self.locator:
             self.locator = _MODISlocator(self, col=self.col,
                                          locator_type=locator_type, **kwargs)
@@ -580,7 +579,7 @@ class _MODISlocator:
                  col=None,
                  product=None,
                  dateline=False,
-                 locator_type='BallTree',
+                 locator_type='SphereRemap2km',
                  *args,
                  **kwargs
                  ):
@@ -643,6 +642,8 @@ class _MODISlocator:
 class _MODISlocatorBallTree:
     """Converts lat-lon to MODIS grid locations for a specified accuracy (factor)"""
     def __init__(self, lon, lat, factor=2, *args, **kwargs):
+        from sklearn.neighbors import BallTree
+
         # FUTURE: Transform coordinates then use cKDTree for speed
         self.factor = factor
         self.locator_tree = BallTree(

--- a/csat2/MODIS/granule.py
+++ b/csat2/MODIS/granule.py
@@ -681,7 +681,7 @@ class _MODISlocatorBallTree:
         output = np.array(self._unraveler(loc_ind[1]))
         if remove_outside:
             os_points = np.where(loc_ind[0] * 6378 > filter_outside)
-            # Cannot use nan here as index array
+            # Cannot use nan here as int array
             output[os_points[0]] = -1
         return output
 
@@ -706,8 +706,8 @@ class _MODISlocatorFullSearch:
             if mindist > 10:
                 output.append([-1, -1])
             else:
-                output.append(np.where(dists == dists.min()))
-        return output
+                output.append(np.array(np.where(dists == dists.min())).squeeze())
+        return np.array(output)
 
     def points_in_radius(self, loc, dist):
         dists = csat2.misc.haversine(*loc, self.lon, self.lat)

--- a/csat2/MODIS/readfiles.py
+++ b/csat2/MODIS/readfiles.py
@@ -23,6 +23,33 @@ def setCollection(col):
     log.info("MODIS default is collection {}".format(DEFAULT_COLLECTION))
 
 
+####################
+# Helper functions #
+####################
+
+def _modis_scale_variable(vdata, var):
+    try:
+        add_offset = var.add_offset
+    except AttributeError:
+        add_offset = 0
+    try:
+        scale_factor = var.scale_factor
+    except AttributeError:
+        scale_factor = 1
+
+    if scale_factor ==1 and add_offset == 0:
+        return vdata
+    else:
+        return (vdata - add_offset) * scale_factor
+
+def _modis_mask_variable(vdata, var):
+    try:
+        vdata = np.where(vdata == var._Fillvalue, np.nan, vdata)
+    except AttributeError:  # No fill value
+        pass
+    return vdata
+    
+
 ###################
 # Readin function #
 ###################
@@ -134,10 +161,7 @@ def readin_MODIS_L3_filename(filename, names):
             var.set_auto_scale(False)
             dims = ["time"] + [a.replace(":mod08", "") for a in var.dimensions]
             units = var.units
-            try:
-                indata = (var[:] - var.add_offset) * var.scale_factor
-            except AttributeError:  # No scale factors
-                indata = var[:]
+            indata = _modis_scale_variable(var[:], var)
             indata = np.ma.filled(indata, np.nan)
             ds[name] = xr.DataArray(indata[None, :, :], dims=dims)
             ds[name].attrs["units"] = units
@@ -275,14 +299,8 @@ def readin_MODIS_L2_filename(filename, names):
                 a.replace(":mod08", "").replace(":MODIS_SWATH_Type_L1B", "").replace(":MODIS_Swath_Type_GEO", "")
                 for a in var.dimensions
             ]
-            try:
-                indata = (var[:] - var.add_offset) * var.scale_factor
-            except AttributeError:  # No scale factors
-                indata = var[:]
-            try:
-                indata = np.where(indata == var._Fillvalue, np.nan, indata)
-            except AttributeError:  # No fill value
-                pass
+            indata = _modis_scale_variable(var[:], var)
+            indata = _modis_mask_variable(indata, var)
             ds[name] = xr.DataArray(indata, dims=dims)
             try:
                 ds[name].attrs["units"] = var.units
@@ -320,14 +338,8 @@ def readin_MODIS_L2_filename_fast(filename, names, varind=None):
                     a.replace(":mod08", "").replace(":MODIS_SWATH_Type_L1B", "").replace(":MODIS_Swath_Type_GEO", "")
                     for a in var.dimensions
                 ]
-            try:
-                indata = (vdata - var.add_offset) * var.scale_factor
-            except AttributeError:  # No scale factors
-                indata = vdata
-            try:
-                indata = np.where(indata == var._Fillvalue, np.nan, indata)
-            except AttributeError:  # No fill value
-                pass
+            indata = _modis_scale_variable(vdata, var)
+            indata = _modis_mask_variable(indata, var)
             ds[name] = xr.DataArray(indata, dims=dims)
             try:
                 ds[name].attrs["units"] = var.units
@@ -342,6 +354,8 @@ def readin_MODIS_L2_filename_fast(filename, names, varind=None):
                 pass
         return ds
 
+
+    
 
 def readin_MODIS_GEOMETA(year, doy, sat="aqua"):
     if sat not in ["aqua", "terra"]:

--- a/csat2/MODIS/readfiles.py
+++ b/csat2/MODIS/readfiles.py
@@ -272,7 +272,7 @@ def readin_MODIS_L2_filename(filename, names):
             var.set_auto_scale(False)
             var.set_auto_mask(False)
             dims = [
-                a.replace(":mod08", "").replace(":MODIS_SWATH_Type_L1B", "")
+                a.replace(":mod08", "").replace(":MODIS_SWATH_Type_L1B", "").replace(":MODIS_Swath_Type_GEO", "")
                 for a in var.dimensions
             ]
             try:
@@ -311,13 +311,13 @@ def readin_MODIS_L2_filename_fast(filename, names, varind=None):
             if (varind is not None) and len(ncdf.variables[name].shape) > 2:
                 vdata = var[varind]
                 dims = [
-                    a.replace(":mod08", "").replace(":MODIS_SWATH_Type_L1B", "")
+                    a.replace(":mod08", "").replace(":MODIS_SWATH_Type_L1B", "").replace(":MODIS_Swath_Type_GEO", "")
                     for a in var.dimensions[1:]
                 ]
             else:
                 vdata = var[:]
                 dims = [
-                    a.replace(":mod08", "").replace(":MODIS_SWATH_Type_L1B", "")
+                    a.replace(":mod08", "").replace(":MODIS_SWATH_Type_L1B", "").replace(":MODIS_Swath_Type_GEO", "")
                     for a in var.dimensions
                 ]
             try:

--- a/doc/instruments.rst
+++ b/doc/instruments.rst
@@ -43,17 +43,6 @@ You can then return information about the granule - note that this requires the 
    >>> gran.daynight()
    'D'
 
-
-The granule object can also provide the approximate nearest pixel to a list of lon-lat points (points are always given in a ``[lon, lat]`` format. Sun and observation zenith angles can also be calculated, along with the interpolated lon-lat locations for each pixel.
-
-.. code-block:: python
-
-   >>> gran.locate([[-130, 31]])
-   array([[ 774, 1322]])
-   >>> sunz, suna, satz, sata, azidiff = gran.get_angles(mst=False)
-   >>> lon, lat = gran.get_lonlat()
-
-
 To get data for a granule, you can read a variable direct from a file, using the ``get_variable`` method, or get brightness temperature/reflectance data from the radiance product ``021KM`` (use ``refl=True``) to get reflectance. Set ``bowtie_corr=True`` to re-order the edge of swath pixels to account for the bowtie effect.
 
 .. code-block:: python
@@ -64,11 +53,33 @@ To get data for a granule, you can read a variable direct from a file, using the
    >>> refl2 = gran.get_band_radiance(2, refl=True, bowtie_corr=False)
 
 
-Finally, you can step forward a specified number of granules
+You can step forward a specified number of granules
 
 .. code-block:: python
 
    >>> newgran = gran.increment(number=1)
+
+Sun and observation zenith angles can also be calculated, along with the interpolated lon-lat locations for each pixel.
+
+.. code-block:: python
+
+   >>> sunz, suna, satz, sata, azidiff = gran.get_angles(mst=False)
+   >>> lon, lat = gran.get_lonlat()
+
+   
+   
+The granule object can also provide the approximate nearest pixel to a list of lon-lat points (points are always given in a ``[lon, lat]`` format. by default this is only approximate (to with +/- 1 gridbox). You can switch to an exact locator by changing the ``locator_type`` argument. If you only want to locate a small number of points, using ``locator_type='FullSearch'`` can be faster. There is more information about the different lcoators and their speed in the examples folder.
+
+
+.. code-block:: python
+
+   >>> gran.locate([[-130, 31]])
+   array([[ 774, 1322]])
+   >>> gran.locate([[-130, 31]], locator_type='SphereRemap')
+   array([[ 774, 1322]])
+
+
+
 
    
 Downloading MODIS data

--- a/examples/modis_locator_speed.py
+++ b/examples/modis_locator_speed.py
@@ -1,0 +1,43 @@
+from csat2 import MODIS
+import matplotlib.pyplot as plt
+import copy
+import numpy as np
+import time
+
+gran = MODIS.Granule.fromtext("2015001.1220A")
+gran.download('021KM')
+
+pattern_locs = np.array(
+    np.meshgrid(np.arange(5, 2100, 100),
+                np.arange(5, 1350, 65))).T
+geo_locs = gran.geolocate(pattern_locs).reshape((-1, 2))
+
+numbers = [1, 3, 10, 30, 100]
+locators = ['BallTree',
+            'BallTree1km',
+            'FullSearch',
+            'SphereRemap',
+            'SphereRemap2km'
+            ]
+
+timing = {}
+for locator_type in locators:
+    print(locator_type)
+    timing[locator_type] = []
+    for number in numbers:
+        gran_test = copy.deepcopy(gran)
+
+        stime = time.time()
+        calc_plocs = gran_test.locate(
+            geo_locs[:number],
+            locator_type=locator_type
+        )
+        etime = time.time() - stime
+        timing[locator_type].append([number, etime])
+        print(number, etime)
+
+print('{name: <15} '.format(name='NumPoints')+' '.join([f'{n: >6}' for n in numbers]))
+
+print('')
+for name in locators:
+    print(f'{name: <15} '+' '.join(['{n:6.2f}'.format(n=timing[name][n][1]) for n in range(len(numbers))]))

--- a/tests/test_modis.py
+++ b/tests/test_modis.py
@@ -127,6 +127,7 @@ class BaseMODISLocator(unittest.TestCase):
         # Requires that the download tests have passed
         # Some data is required!
         self.gran = MODIS.Granule.fromtext("2015001.1220A")
+        self.polar_gran = MODIS.Granule.fromtext("2015001.1235A")
 
         assert self.locator_type is not None, "Subclasses must set locator_type"
         
@@ -214,6 +215,28 @@ class BaseMODISLocator(unittest.TestCase):
         ).reshape((pattern_locs).shape)
         assert (abs(calc_plocs-pattern_locs) ==0 ).all()
 
+    def test_pattern_locations_poles(self):
+        pattern_locs = np.array(
+            np.meshgrid(np.arange(5, 2100, 200),
+                        np.arange(5, 1350, 130))).T
+        geo_locs = self.polar_gran.geolocate(pattern_locs)
+        calc_plocs = self.polar_gran.locate(
+            geo_locs.reshape((-1, 2)),
+            locator_type=self.locator_type
+        ).reshape((pattern_locs).shape)
+        assert (abs(calc_plocs-pattern_locs) <= 1).all()
+
+    def test_pattern_locations_poles_exact(self):
+        pattern_locs = np.array(
+            np.meshgrid(np.arange(5, 2100, 200),
+                        np.arange(5, 1350, 130))).T
+        geo_locs = self.polar_gran.geolocate(pattern_locs)
+        calc_plocs = self.polar_gran.locate(
+            geo_locs.reshape((-1, 2)),
+            locator_type=self.locator_type
+        ).reshape((pattern_locs).shape)
+        assert (abs(calc_plocs-pattern_locs) ==0 ).all()
+
     def test_locator_invalid(self):
         for loc in self.fail_locs:
             ilon, ilat = loc[1]
@@ -232,6 +255,10 @@ class TestMODISLocator_BallTree(BaseMODISLocator):
     @pytest.mark.xfail
     def test_pattern_locations_exact(self):
         super().test_pattern_locations_exact()
+
+    @pytest.mark.xfail
+    def test_pattern_locations_poles_exact(self):
+        super().test_pattern_locations_poles_exact()
 
 
 class TestMODISLocator_BallTree1km(BaseMODISLocator):
@@ -256,3 +283,7 @@ class TestMODISLocator_SphereRemap2km(BaseMODISLocator):
     @pytest.mark.xfail
     def test_pattern_locations_exact(self):
         super().test_pattern_locations_exact()
+
+    @pytest.mark.xfail
+    def test_pattern_locations_poles_exact(self):
+        super().test_pattern_locations_poles_exact()

--- a/tests/test_modis.py
+++ b/tests/test_modis.py
@@ -237,3 +237,8 @@ class TestMODISLocator_BallTree(BaseMODISLocator):
 class TestMODISLocator_FullSearch(BaseMODISLocator):
     locator_type = 'FullSearch'
     __test__ = True
+
+
+class TestMODISLocator_SphereRemap(BaseMODISLocator):
+    locator_type = 'SphereRemap'
+    __test__ = True

--- a/tests/test_modis.py
+++ b/tests/test_modis.py
@@ -32,7 +32,7 @@ class TestMODISBasic(unittest.TestCase):
 @pytest.mark.network
 class TestMODISDownload(unittest.TestCase):
     def test_MODIS_download(self):
-        gran = MODIS.Granule.fromtext("2015001.2150A")
+        gran = MODIS.Granule.fromtext("2015001.1220A")
         # Remove exisiting file
         try:
             fname = gran.get_filename("021KM")
@@ -48,7 +48,7 @@ class TestMODISDownload(unittest.TestCase):
         assert isinstance(gran.get_filename("021KM"), str)
 
     def test_MODIS_download_geometa(self):
-        gran = MODIS.Granule.fromtext("2015001.2150A")
+        gran = MODIS.Granule.fromtext("2015001.1220A")
         # Remove exisiting file
         try:
             fname = gran.get_filename("GEOMETA")
@@ -76,12 +76,12 @@ class TestMODISGranule(unittest.TestCase):
     def setUp(self):
         # Requires that the download tests have passed
         # Some data is required!
-        self.gran = MODIS.Granule.fromtext("2015001.2150A")
+        self.gran = MODIS.Granule.fromtext("2015001.1220A")
         try:
             self.gran.get_filename("021KM")
         except IndexError:
             pytest.skip(
-                "Test requires 2015001.2150A (MYD021KM)- run with --runnetwork to download automatically"
+                "Test requires 2015001.1220A (MYD021KM)- run with --runnetwork to download automatically"
             )
 
     def test_getfilename(self):
@@ -124,7 +124,7 @@ class TestMODISLocator(unittest.TestCase):
     def setUp(self):
         # Requires that the download tests have passed
         # Some data is required!
-        self.gran = MODIS.Granule.fromtext("2015001.2150A")
+        self.gran = MODIS.Granule.fromtext("2015001.1220A")
 
         self.locs = [
             ["Isla Angel de la Guarda", (-113.1140, 28.9846), (380, 1681)],

--- a/tests/test_modis.py
+++ b/tests/test_modis.py
@@ -234,6 +234,11 @@ class TestMODISLocator_BallTree(BaseMODISLocator):
         super().test_pattern_locations_exact()
 
 
+class TestMODISLocator_BallTree1km(BaseMODISLocator):
+    locator_type = 'BallTree1km'
+    __test__ = True
+        
+
 class TestMODISLocator_FullSearch(BaseMODISLocator):
     locator_type = 'FullSearch'
     __test__ = True
@@ -242,3 +247,12 @@ class TestMODISLocator_FullSearch(BaseMODISLocator):
 class TestMODISLocator_SphereRemap(BaseMODISLocator):
     locator_type = 'SphereRemap'
     __test__ = True
+
+
+class TestMODISLocator_SphereRemap2km(BaseMODISLocator):
+    locator_type = 'SphereRemap2km'
+    __test__ = True
+
+    @pytest.mark.xfail
+    def test_pattern_locations_exact(self):
+        super().test_pattern_locations_exact()


### PR DESCRIPTION
This addresses #36 by providing new locator classes for the MODIS granule. These can be selected by setting 'locator_type' when calling `Granule.locate`.

The current default is now set to `SphereRemap2km`, which is similar to the old `BallTree` locator, but doesn't require scikit learn and is approximately 30% faster. For very small numbers of points (<10 in a granule), `FullSearch` may be faster.

Note that this is still only accurate to +/- 1 gridbox. For an exact match,  set `locator_type` to `SphereRemap`.